### PR TITLE
Support for static members

### DIFF
--- a/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/AgentClassTransformer.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/AgentClassTransformer.java
@@ -92,7 +92,7 @@ public class AgentClassTransformer implements ClassFileTransformer {
    */
   protected byte[] instrumentClass(String name, byte[] classfileBuffer) {
     try {
-      return javaassist.instrumentClass(name,
+      return javaassist.instrumentClassWithStaticStmt(name,
               AgentClassTransformer.class.getName()
                       + ".add(\"" + name + "\");");
     } catch (Throwable e) {

--- a/junit4git/src/test/java/org/walkmod/junit4git/core/bytecode/AgentClassTransformerTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/core/bytecode/AgentClassTransformerTest.java
@@ -54,7 +54,7 @@ public class AgentClassTransformerTest {
             Dummy.class,
             this.getClass().getProtectionDomain(), new byte[0]);
 
-    verify(javassist).instrumentClass("org.walkmod.junit4git.core.Dummy",
+    verify(javassist).instrumentClassWithStaticStmt("org.walkmod.junit4git.core.Dummy",
             AgentClassTransformer.class.getName() + ".add(\"" +  Dummy.class.getName() + "\");");
   }
 }

--- a/junit4git/src/test/java/org/walkmod/junit4git/javassist/JavassistUtilsTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/javassist/JavassistUtilsTest.java
@@ -95,14 +95,56 @@ public class JavassistUtilsTest {
     String field = "x";
 
     CtClass evalClass = pool.makeClass(instrumentedClass);
-    evalClass.addField(CtField.make("public int " + field + ";", evalClass));
+    evalClass.addField(CtField.make("public static int " + field + ";", evalClass));
     evalClass.addConstructor(CtNewConstructor.defaultConstructor(evalClass));
 
-    javassist.instrumentClass(instrumentedClass, field + " = 2;");
+    javassist.instrumentClassWithStaticStmt(instrumentedClass, field + " = 2;");
 
     Class clazz = pool.get(instrumentedClass).toClass();
     Object o = clazz.newInstance();
     Assert.assertEquals(2, o.getClass().getField(field).get(o));
+  }
+
+  @Test
+  public void it_instruments_static_constructors() throws Exception {
+
+    JavassistUtils javassist = new JavassistUtils();
+    ClassPool pool = ClassPool.getDefault();
+
+    String instrumentedClass = "InstrumentedClassWithoutMethods";
+    String field = "x";
+
+    CtClass evalClass = pool.makeClass(instrumentedClass);
+    evalClass.addField(CtField.make("public static int " + field + ";", evalClass));
+
+    javassist.instrumentClassWithStaticStmt(instrumentedClass, field + " = 2;");
+
+    Class clazz = pool.get(instrumentedClass).toClass();
+    Assert.assertEquals(2, clazz.getField(field).get(null));
+
+  }
+
+  @Test
+  public void it_instruments_static_methods() throws Exception {
+    JavassistUtils javassist = new JavassistUtils();
+    ClassPool pool = ClassPool.getDefault();
+
+    String instrumentedClass = "InstrumentedClassWithStaticMethods";
+    String field = "x";
+
+    CtClass evalClass = pool.makeClass(instrumentedClass);
+    evalClass.addField(CtField.make("public static int " + field + ";", evalClass));
+
+    CtMethod method = CtNewMethod.make(
+            "public static int xValue() { return 2; }",
+            evalClass);
+    evalClass.addMethod(method);
+
+    javassist.instrumentClassWithStaticStmt(instrumentedClass, field + " = 2;");
+
+    Class clazz = pool.get(instrumentedClass).toClass();
+    clazz.getMethod("xValue").invoke(null);
+    Assert.assertEquals(2, clazz.getField(field).get(null));
   }
 
 }


### PR DESCRIPTION
This patch adds support to monitor when a class is loaded
or the static methods are executed. Then, for example, if a
class is loaded dynamically by spring when the test starts,
this is instrumented.

If fields are accessed and they do not have a related behavior
to the class, they should be ignored.