### PR TITLE
scalatest FuncSuite support

### DIFF
--- a/junit4git/build.gradle
+++ b/junit4git/build.gradle
@@ -10,6 +10,23 @@ dependencies {
     testCompile group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
 }
 
+Map <String, ?> attrs = [ 'Premain-Class': 'org.walkmod.junit4git.core.ignorers.TestIgnorerAgent',
+                          'Can-Retransform-Classes': true,
+                          'Boot-Class-Path': 'junit4git-agent.jar'
+]
+
+task customFatJar(type: Jar) {
+    manifest {
+        attributes attrs
+    }
+    baseName = 'junit4git-agent'
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it)}
+    }
+    exclude ('**/*.RSA')
+    with jar
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/TestIgnorerTransformer.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/TestIgnorerTransformer.java
@@ -1,0 +1,56 @@
+package org.walkmod.junit4git.core.bytecode;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.walkmod.junit4git.core.ignorers.TestIgnorer;
+import org.walkmod.junit4git.core.reports.TestMethodReport;
+import org.walkmod.junit4git.javassist.JavassistUtils;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.security.ProtectionDomain;
+import java.util.*;
+
+
+public class TestIgnorerTransformer implements ClassFileTransformer {
+
+
+  private static Log log = LogFactory.getLog(TestIgnorerTransformer.class);
+
+  private final TestIgnorer testIgnorer;
+
+  private final  Map<String, List<TestMethodReport>> testsToMap;
+
+  public TestIgnorerTransformer(TestIgnorer testIgnorer) throws Exception {
+    this.testIgnorer = testIgnorer;
+    testsToMap = testIgnorer.testsGroupedByClass();
+    log.info("Last Test Impact Analysis: " + testsToMap.size() + " tests");
+  }
+
+  @Override
+  public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined,
+                          ProtectionDomain protectionDomain, byte[] classfileBuffer)
+          throws IllegalClassFormatException {
+    String name = normalizeName(className);
+    try {
+      if (testsToMap.containsKey(name)) {
+        log.info("Ignoring " + name);
+        return testIgnorer.ignoreTest(name, testsToMap.get(name));
+      }
+      return classfileBuffer;
+
+    } catch (Exception e) {
+      log.error("Error ignoring the tests of " + name, e);
+      throw new IllegalClassFormatException("Error ignoring tests on " + name);
+    }
+  }
+
+  private String normalizeName(String className) {
+    String aux = className.replaceAll("/", "\\.");
+    if (aux.endsWith(".class")) {
+      aux = aux.substring(0, aux.length() - ".class".length());
+    }
+    return aux;
+  }
+
+}

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/ignorers/TestIgnorerAgent.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/ignorers/TestIgnorerAgent.java
@@ -1,0 +1,22 @@
+package org.walkmod.junit4git.core.ignorers;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.walkmod.junit4git.core.bytecode.TestIgnorerTransformer;
+import org.walkmod.junit4git.core.reports.GitTestReportStorage;
+
+import java.lang.instrument.Instrumentation;
+
+public class TestIgnorerAgent {
+
+  private static Log log = LogFactory.getLog(TestIgnorerAgent.class);
+
+  public static void premain(String args, Instrumentation instrumentation) {
+    log.info("JUnit4Git agent started");
+    try {
+      instrumentation.addTransformer(new TestIgnorerTransformer(new TestIgnorer(new GitTestReportStorage())));
+    } catch (Exception e) {
+      log.error(e);
+    }
+  }
+}

--- a/scalatest4git_211/src/test/scala/org/scalatest/junit/TestIgnorerTest.scala
+++ b/scalatest4git_211/src/test/scala/org/scalatest/junit/TestIgnorerTest.scala
@@ -1,0 +1,49 @@
+package org.scalatest.junit
+
+import java.lang.instrument.Instrumentation
+import java.util
+
+import org.junit.Test
+import org.scalatest.FunSuite
+import org.scalatest.mockito.MockitoSugar
+import org.walkmod.junit4git.core.ignorers.TestIgnorer
+import org.walkmod.junit4git.core.reports.{AbstractTestReportStorage, TestMethodReport}
+import org.mockito.Mockito.when
+import org.mockito.Mockito.verify
+import org.mockito.Matchers.any
+import org.walkmod.junit4git.javassist.JavassistUtils
+
+class TestIgnorerTest extends MockitoSugar {
+
+  @Test
+  def testReplacesTestsByIgnores(): Unit = {
+    val testReportStorage = mock[AbstractTestReportStorage]
+    val javassist = mock[JavassistUtils]
+
+    val testIgnorer = new TestIgnorer(".", testReportStorage, javassist) {
+
+      protected override def getTestsToIgnore(report: Array[TestMethodReport]): util.Set[TestMethodReport] = {
+        val result = new util.HashSet[TestMethodReport]()
+        result.add(report(0))
+        result
+      }
+    }
+
+    val instrumentation = mock[Instrumentation]
+
+    when(testReportStorage.getBaseReport).thenReturn(
+      Array(new TestMethodReport(classOf[MyTestClass].getName, "hello junit4git", new util.HashSet())))
+
+    testIgnorer.ignoreTests(instrumentation)
+
+    verify(javassist).replaceMethodCallOnConstructors(any(), any(), any())
+  }
+
+}
+
+class MyTestClass extends FunSuite {
+
+  test("hello junit4git") {
+
+  }
+}


### PR DESCRIPTION
This patch adds support for FuncSuite with the following changes:

- New agent to define for ignoring tests because when the runner loads
the test ignorer, the class has been already loaded, which means that
can not be changed.

- Checking if the test extends from FuncSuite

- ScalaTest creates a constructor per Test class, and inside the constructor, calls the tests.
This patch ignores this kind of tests by replacing the method call "test" by "ignore".