### PR TITLE
Refactor for Runner + Agent

### DIFF
--- a/junit4git/src/main/java/org/walkmod/junit4git/core/TestsReportClient.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/TestsReportClient.java
@@ -28,19 +28,27 @@ public class TestsReportClient {
   private static final String SERVER_TEST_REPORT_URL = "http://localhost:9000";
 
   public TestsReportClient() {
-    this(new OkHttpClient(), !loaded);
+    this(false);
   }
 
-  public TestsReportClient(OkHttpClient client, boolean startupServer) {
+  public TestsReportClient(boolean fromRunner) {
+    this(new OkHttpClient(), !loaded, fromRunner);
+  }
+
+  public TestsReportClient(OkHttpClient client, boolean startupServer, boolean fromRunner) {
     this.client = client;
     if (startupServer) {
-      startUpAgentServer();
+      startUpAgentServer(fromRunner);
       System.out.println("Junit4Git started [SUCCESS]");
     }
   }
 
-  protected void startUpAgentServer() {
-    AgentLoader.loadAgentClass(TestsReportServer.class.getName(), "");
+  protected void startUpAgentServer(boolean fromRunner) {
+    String options = "";
+    if (fromRunner) {
+      options += "--fromRunner";
+    }
+    AgentLoader.loadAgentClass(TestsReportServer.class.getName(), options);
     loaded = true;
   }
 

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/TestIgnorerTransformer.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/TestIgnorerTransformer.java
@@ -34,7 +34,7 @@ public class TestIgnorerTransformer implements ClassFileTransformer {
     String name = normalizeName(className);
     try {
       if (testsToMap.containsKey(name)) {
-        log.info("Ignoring " + name);
+        log.debug("Ignoring " + name);
         return testIgnorer.ignoreTest(name, testsToMap.get(name));
       }
       return classfileBuffer;

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/TestIgnorerTransformer.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/bytecode/TestIgnorerTransformer.java
@@ -24,7 +24,6 @@ public class TestIgnorerTransformer implements ClassFileTransformer {
   public TestIgnorerTransformer(TestIgnorer testIgnorer) throws Exception {
     this.testIgnorer = testIgnorer;
     testsToMap = testIgnorer.testsGroupedByClass();
-    log.info("Last Test Impact Analysis: " + testsToMap.size() + " tests");
   }
 
   @Override

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/reports/AbstractTestReportStorage.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/reports/AbstractTestReportStorage.java
@@ -23,7 +23,7 @@ public abstract class AbstractTestReportStorage {
    * Method called before any read or writing operation; whose purpose
    * is to initialize/prepare the required resources.
    */
-  public abstract void prepare();
+  public abstract ReportStatus prepare();
 
   /**
    * Reads the test impact report

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/reports/GitTestReportStorage.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/reports/GitTestReportStorage.java
@@ -64,13 +64,17 @@ public class GitTestReportStorage extends AbstractTestReportStorage {
     this.executionDir = executionDir;
   }
 
-  public void prepare() {
+  public ReportStatus prepare() {
     try (Git git = open()) {
       Ref ref = fetchNotesRef(git);
       if (ref == null) {
         createGitNotesRef(git);
+        return ReportStatus.CLEAN;
       } else if (isClean(git)) {
         removeLastNote(git);
+        return ReportStatus.CLEAN;
+      } else {
+        return ReportStatus.DIRTY;
       }
     } catch (Exception e) {
       throw new RuntimeException("Error removing the existing Git notes in " + GIT_NOTES_REF, e);

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/reports/ReportStatus.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/reports/ReportStatus.java
@@ -1,0 +1,5 @@
+package org.walkmod.junit4git.core.reports;
+
+public enum ReportStatus {
+  CLEAN, DIRTY
+}

--- a/junit4git/src/main/java/org/walkmod/junit4git/javassist/JavassistUtils.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/javassist/JavassistUtils.java
@@ -106,17 +106,16 @@ public class JavassistUtils {
     CtClass clazz = pool.get(className);
 
     if (clazz.isFrozen()) {
-      clazz.defrost();
-      clazz.detach();
+      return clazz.toBytecode();
     }
 
     for (CtConstructor ctConstructor : clazz.getConstructors()) {
       ctConstructor.insertAfter(instrumentationInstruction);
     }
 
-    CtMethod[] methods = clazz.getMethods();
+    CtMethod[] methods = clazz.getDeclaredMethods();
     if (methods != null) {
-      for (CtMethod ctMethod : clazz.getMethods()) {
+      for (CtMethod ctMethod : clazz.getDeclaredMethods()) {
         if (Modifier.isStatic(ctMethod.getModifiers())) {
           ctMethod.insertAfter(instrumentationInstruction, true);
         }

--- a/junit4git/src/main/java/org/walkmod/junit4git/junit4/Junit4GitListener.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/junit4/Junit4GitListener.java
@@ -13,6 +13,10 @@ public class Junit4GitListener extends RunListener {
     this(new TestsReportClient());
   }
 
+  public Junit4GitListener(boolean fromRunner) {
+    this(new TestsReportClient(fromRunner));
+  }
+
   public Junit4GitListener(TestsReportClient client) {
     this.client = client;
   }

--- a/junit4git/src/main/java/org/walkmod/junit4git/junit4/Junit4GitRunner.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/junit4/Junit4GitRunner.java
@@ -14,7 +14,7 @@ public class Junit4GitRunner extends BlockJUnit4ClassRunner {
 
   static {
     try {
-      listener = new Junit4GitListener();
+      listener = new Junit4GitListener(true);
     } catch (Exception e) {
       log.error("Error launching the Runner ", e);
     }

--- a/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportClientTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportClientTest.java
@@ -24,7 +24,7 @@ public class TestsReportClientTest {
     OkHttpClient http = mock(OkHttpClient.class);
     when(http.newCall(any())).thenReturn(mock(Call.class));
 
-    TestsReportClient client = new TestsReportClient(http, false);
+    TestsReportClient client = new TestsReportClient(http, false, false);
     ArgumentCaptor<Request> argumentCaptor = ArgumentCaptor.forClass(Request.class);
     client.sendRequestToClassLoggerAgent("FooClass", "bar",
             JUnitEventType.START.getName());

--- a/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportServerTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportServerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 public class TestsReportServerTest {
 
   @Test
-  public void test_when_a_start_event_arrives_the_referenced_classes_of_the_previous_test_are_clean() {
+  public void test_when_a_start_event_arrives_the_referenced_classes_of_the_previous_test_are_clean() throws Exception {
     AgentClassTransformer.add("Foo");
     TestsReportServer server = new TestsReportServer(new GitTestReportStorage());
     server.process(new JUnitEvent(JUnitEventType.START.getName(), "FooClass", "test_method"));
@@ -23,7 +23,7 @@ public class TestsReportServerTest {
   }
 
   @Test
-  public void test_when_a_stop_event_arrives_the_test_is_stored() {
+  public void test_when_a_stop_event_arrives_the_test_is_stored() throws Exception {
     AbstractTestReportStorage storage = mock(AbstractTestReportStorage.class);
     TestsReportServer server = new TestsReportServer(storage);
     server.process(new JUnitEvent(JUnitEventType.STOP.getName(), "FooClass", "test_method"));

--- a/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportServerTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportServerTest.java
@@ -5,19 +5,24 @@ import org.junit.Test;
 import org.walkmod.junit4git.core.bytecode.AgentClassTransformer;
 import org.walkmod.junit4git.core.reports.AbstractTestReportStorage;
 import org.walkmod.junit4git.core.reports.GitTestReportStorage;
+import org.walkmod.junit4git.core.reports.ReportStatus;
 import org.walkmod.junit4git.core.reports.TestMethodReport;
 
 import java.util.Collections;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class TestsReportServerTest {
 
   @Test
   public void test_when_a_start_event_arrives_the_referenced_classes_of_the_previous_test_are_clean() throws Exception {
     AgentClassTransformer.add("Foo");
-    TestsReportServer server = new TestsReportServer(new GitTestReportStorage());
+    AbstractTestReportStorage storage = mock(AbstractTestReportStorage.class);
+    when(storage.prepare()).thenReturn(ReportStatus.CLEAN);
+
+    TestsReportServer server = new TestsReportServer(storage);
     server.process(new JUnitEvent(JUnitEventType.START.getName(), "FooClass", "test_method"));
     Assert.assertEquals(Collections.EMPTY_SET, AgentClassTransformer.getReferencedClasses());
   }
@@ -25,6 +30,7 @@ public class TestsReportServerTest {
   @Test
   public void test_when_a_stop_event_arrives_the_test_is_stored() throws Exception {
     AbstractTestReportStorage storage = mock(AbstractTestReportStorage.class);
+    when(storage.prepare()).thenReturn(ReportStatus.CLEAN);
     TestsReportServer server = new TestsReportServer(storage);
     server.process(new JUnitEvent(JUnitEventType.STOP.getName(), "FooClass", "test_method"));
     verify(storage).appendTestReport(new TestMethodReport("FooClass", "test_method",

--- a/junit4git/src/test/java/org/walkmod/junit4git/core/reports/FileTestReportStorage.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/core/reports/FileTestReportStorage.java
@@ -13,13 +13,14 @@ public class FileTestReportStorage extends AbstractTestReportStorage {
   private File baseReport = new File("smart-testing-report.base.json");
 
   @Override
-  public void prepare() {
+  public ReportStatus prepare() {
     try (Writer writer = buildWriter()) {
       writer.write("");
       writer.flush();
     } catch (IOException e) {
       e.printStackTrace();
     }
+    return ReportStatus.CLEAN;
   }
 
   @Override

--- a/scalatest4git_211/src/main/scala/org/scalatest/junit/ScalaGitRunner.scala
+++ b/scalatest4git_211/src/main/scala/org/scalatest/junit/ScalaGitRunner.scala
@@ -8,7 +8,7 @@ import org.walkmod.junit4git.junit4.Junit4GitListener
 
 class ScalaGitRunner(suiteClass: java.lang.Class[_ <: Suite]) extends org.junit.runner.Runner {
 
-  var listener:Junit4GitListener = new Junit4GitListener()
+  var listener:Junit4GitListener = new Junit4GitListener(true)
 
   val log = LogFactory.getLog(classOf[ScalaGitRunner])
 


### PR DESCRIPTION
It refactorizes the project to skip the test ignoring process
from the Test Runner execution, because it needs to rely into an
external agent. Otherwise, the test class has been already loaded and
can not be modified with the @ignore annotations.