### PR TITLE
Incremental execution for scalatest

### DIFF
--- a/junit4git/src/main/java/org/walkmod/junit4git/core/ignorers/TestIgnorer.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/ignorers/TestIgnorer.java
@@ -167,8 +167,7 @@ public class TestIgnorer {
     clazz.defrost();
     ClassFile ccFile = clazz.getClassFile();
     if (isScalaTest(clazz)) {
-      //TODO: Filter by test method (ie. constructor)
-      javassist.replaceMethodCallOnConstructors("test", "ignore", clazz);
+      javassist.replaceMethodCallOnConstructors("test", "ignore", clazz, methods);
       log.debug("The scala test class " + className + " has been processed");
     } else {
       ConstPool constpool = ccFile.getConstPool();

--- a/junit4git/src/main/java/org/walkmod/junit4git/core/ignorers/TestIgnorerAgent.java
+++ b/junit4git/src/main/java/org/walkmod/junit4git/core/ignorers/TestIgnorerAgent.java
@@ -4,6 +4,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.walkmod.junit4git.core.bytecode.TestIgnorerTransformer;
 import org.walkmod.junit4git.core.reports.GitTestReportStorage;
+import org.walkmod.junit4git.core.reports.ReportStatus;
 
 import java.lang.instrument.Instrumentation;
 
@@ -14,7 +15,11 @@ public class TestIgnorerAgent {
   public static void premain(String args, Instrumentation instrumentation) {
     log.info("JUnit4Git agent started");
     try {
-      instrumentation.addTransformer(new TestIgnorerTransformer(new TestIgnorer(new GitTestReportStorage())));
+      GitTestReportStorage storage = new GitTestReportStorage();
+      ReportStatus status = storage.getStatus();
+      if (status.equals(ReportStatus.DIRTY)) {
+        instrumentation.addTransformer(new TestIgnorerTransformer(new TestIgnorer(new GitTestReportStorage())));
+      }
     } catch (Exception e) {
       log.error(e);
     }

--- a/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportServerTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/core/TestsReportServerTest.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.walkmod.junit4git.core.bytecode.AgentClassTransformer;
 import org.walkmod.junit4git.core.reports.AbstractTestReportStorage;
-import org.walkmod.junit4git.core.reports.GitTestReportStorage;
 import org.walkmod.junit4git.core.reports.ReportStatus;
 import org.walkmod.junit4git.core.reports.TestMethodReport;
 

--- a/junit4git/src/test/java/org/walkmod/junit4git/javassist/JavassistUtilsTest.java
+++ b/junit4git/src/test/java/org/walkmod/junit4git/javassist/JavassistUtilsTest.java
@@ -157,11 +157,11 @@ public class JavassistUtilsTest {
     superClass.addField(CtField.make("public int x = 0;", superClass));
 
     superClass.addMethod(CtNewMethod.make(
-            "public int foo() { x += 1; return x; }",
+            "public void test(String name) { x += 1; }",
             superClass));
 
     superClass.addMethod(CtNewMethod.make(
-            "public int bar() { x += 2; return x;}",
+            "public void ignore(String name) { x += 2; }",
             superClass));
 
     superClass.addMethod(CtNewMethod.make(
@@ -173,12 +173,17 @@ public class JavassistUtilsTest {
     evalClass.setSuperclass(superClass);
 
     evalClass.addConstructor(
-            CtNewConstructor.make("public InstrumentedClassWithChangedMethods() { foo(); foo(); }",
+            CtNewConstructor.make("public InstrumentedClassWithChangedMethods() { test(\"test1\"); test(\"test2\"); }",
                     evalClass));
 
     Class<?> parent = superClass.toClass();
 
-    javassist.replaceMethodCallOnConstructors("foo", "bar", evalClass);
+    List<TestMethodReport> testsToIgnore = new LinkedList<>();
+
+    testsToIgnore.add(new TestMethodReport("InstrumentedClassWithChangedMethods", "test1", null));
+    testsToIgnore.add(new TestMethodReport("InstrumentedClassWithChangedMethods", "test2", null));
+
+    javassist.replaceMethodCallOnConstructors("test", "ignore", evalClass, testsToIgnore);
 
     Class<?> clazz = evalClass.toClass();
     Object newInstance = clazz.newInstance();

--- a/scalatest4git_211/src/test/scala/org/scalatest/junit/TestIgnorerTest.scala
+++ b/scalatest4git_211/src/test/scala/org/scalatest/junit/TestIgnorerTest.scala
@@ -36,7 +36,7 @@ class TestIgnorerTest extends MockitoSugar {
 
     testIgnorer.ignoreTests(instrumentation)
 
-    verify(javassist).replaceMethodCallOnConstructors(any(), any(), any())
+    verify(javassist).replaceMethodCallOnConstructors(any(), any(), any(), any())
   }
 
 }


### PR DESCRIPTION
This patch improves these points:

- The agent for ignoring tests, only runs if the status is DIRTY (base branch contains changes or
the working branch is another one).

- The scalatest that are ignored are the only one reported according the set of changes instead
of ignoring all that belong to the same test class.